### PR TITLE
docs: standardize Go package documentation and add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
 # jourlog
 
-A Go package for logging to systemd's journal with advanced features.
-
-## Features
-
-- Log to systemd journal with proper metadata
-- Support for all standard log levels (Emergency, Alert, Critical, Error, Warning, Notice, Info, Debug)
-- Context-aware logging to include request IDs, user IDs, and other metadata
-- Capture file, line, and function information for each log entry
-- Option to echo logs to console
-- Journal reading capabilities with filtering options
+`jourlog` is a Go package for writing structured logs to `systemd-journald` and reading logs back using journal filters.
 
 ## Installation
 
@@ -17,197 +8,83 @@ A Go package for logging to systemd's journal with advanced features.
 go get github.com/yskomur/jourlog
 ```
 
-## Usage
-
-### Basic Logging
+## Quick start
 
 ```go
 package main
 
 import (
-    "github.com/yskomur/jourlog"
+	"github.com/coreos/go-systemd/v22/journal"
+	"github.com/yskomur/jourlog"
 )
 
 func main() {
-    // Use the global logger
-    jourlog.JLog.Info("Application started")
+	logger := jourlog.NewJourlog()
+	logger.SetLogLevel(journal.PriInfo)
+	logger.SetEcho(true)
 
-    // Log with formatting
-    jourlog.JLog.Info("User %s logged in", "john.doe")
-
-    // Log an error
-    jourlog.JLog.Error("Failed to connect to database: %v", err)
-
-    // Set log level
-    jourlog.JLog.SetLogLevel(journal.PriDebug)
-
-    // Enable console output
-    jourlog.JLog.SetEcho(true)
+	logger.Info("application started")
+	logger.Error("database unavailable")
 }
 ```
 
-### Reading from Journal
+## Read from journal
 
 ```go
 package main
 
 import (
-    "fmt"
-    "github.com/yskomur/jourlog"
-    "time"
+	"fmt"
+	"log"
+
+	"github.com/yskomur/jourlog"
 )
 
 func main() {
-    // Create a journal reader
-    reader, err := jourlog.NewJournalReader()
-    if err != nil {
-        fmt.Printf("Failed to create journal reader: %v\n", err)
-        return
-    }
-    // Don't forget to close the reader when done
-    defer reader.Close()
+	reader, err := jourlog.NewJournalReader()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer reader.Close()
 
-    // Configure to read SSH service logs from the last hour
-    if err := reader.LastHour(); err != nil {
-        fmt.Printf("Failed to set time filter: %v\n", err)
-        return
-    }
+	if err := reader.LastHour(); err != nil {
+		log.Fatal(err)
+	}
 
-    // Read entries
-    for {
-        message, err := reader.Retrieve()
-        if err != nil {
-            if err.Error() == "no more entries" {
-                break
-            }
-            fmt.Printf("Error reading journal: %v\n", err)
-            break
-        }
-
-        fmt.Println(message)
-    }
+	for {
+		message, err := reader.Retrieve()
+		if err != nil {
+			break
+		}
+		fmt.Println(message)
+	}
 }
 ```
 
-### Advanced Journal Reading
+## API overview
 
-```go
-package main
+### Logging (`JourLog`)
 
-import (
-    "fmt"
-    "github.com/yskomur/jourlog"
-    "time"
-)
+- `NewJourlog()` creates a logger.
+- `SetLogLevel(...)` sets the minimum accepted priority.
+- `SetEcho(true)` mirrors messages to stdout.
+- Priority helpers: `Emerge`, `Alert`, `Critical`, `Error`, `Warning`, `Notice`, `Info`, `Debug`.
 
-func main() {
-    // Create a journal reader
-    reader, err := jourlog.NewJournalReader()
-    if err != nil {
-        fmt.Printf("Failed to create journal reader: %v\n", err)
-        return
-    }
-    // Always close the reader when done to release resources
-    defer reader.Close()
+Each log record includes caller metadata fields (`CODE_FILE`, `CODE_LINE`, `CODE_FUNC`) in journald.
 
-    // Set filters for specific service and unit
-    if err := reader.SetService("ssh"); err != nil {
-        fmt.Printf("Failed to set service filter: %v\n", err)
-        return
-    }
+### Journal reading (`JournalReader`)
 
-    // Set time range (last 24 hours)
-    if err := reader.LastDay(); err != nil {
-        fmt.Printf("Failed to set time filter: %v\n", err)
-        return
-    }
+- `NewJournalReader()` opens a journal reader.
+- Time filters: `SetSince`, `SetUntil`, `LastHour`, `LastDay`, `LastWeek`, `Today`.
+- Match filters: `SetUnit`, `SetService`, `SetPriority`, `SetHostname`, `SetExecutable`, `SetMessageFilter`, `AddFilter`.
+- Cursor helpers: `SeekHead`, `SeekTail`, `SeekCursor`, `GetCursor`.
+- Limits and state: `SetLimit`, `ResetCounter`, `ClearFilters`.
 
-    // Alternative: Set custom time range
-    // startTime := time.Now().Add(-6 * time.Hour)
-    // if err := reader.SetSince(startTime); err != nil {
-    //     fmt.Printf("Failed to set start time: %v\n", err)
-    //     return
-    // }
+## Documentation
 
-    // Set priority filter (only warning and above)
-    if err := reader.SetPriority(4); err != nil {
-        fmt.Printf("Failed to set priority filter: %v\n", err)
-        return
-    }
-
-    // Set hostname filter
-    if err := reader.SetHostname("myserver"); err != nil {
-        fmt.Printf("Failed to set hostname filter: %v\n", err)
-        return
-    }
-
-    // Set limit to retrieve only 100 entries
-    reader.SetLimit(100)
-
-    // Move to the beginning of the journal
-    if err := reader.SeekHead(); err != nil {
-        fmt.Printf("Failed to seek to head: %v\n", err)
-        return
-    }
-
-    // Read entries
-    entryCount := 0
-    for {
-        message, err := reader.Retrieve()
-        if err != nil {
-            if err.Error() == "no more entries" || err.Error() == "reached limit of 100 entries" {
-                break
-            }
-            fmt.Printf("Error reading journal: %v\n", err)
-            break
-        }
-
-        fmt.Printf("%d: %s\n", entryCount+1, message)
-        entryCount++
-    }
-
-    fmt.Printf("Retrieved %d entries\n", entryCount)
-
-    // Clear all filters for a new query
-    reader.ClearFilters()
-
-    // Reset the counter
-    reader.ResetCounter()
-
-    // Set a new filter for today's logs only
-    if err := reader.Today(); err != nil {
-        fmt.Printf("Failed to set today filter: %v\n", err)
-        return
-    }
-
-    // Get and save the current cursor position
-    cursor, err := reader.GetCursor()
-    if err != nil {
-        fmt.Printf("Failed to get cursor: %v\n", err)
-    } else {
-        fmt.Printf("Current cursor position: %s\n", cursor)
-
-        // Later, you can seek back to this position
-        // if err := reader.SeekCursor(cursor); err != nil {
-        //     fmt.Printf("Failed to seek to cursor: %v\n", err)
-        // }
-    }
-}
-```
-
-## Log Levels
-
-The package supports the following log levels, in order of decreasing severity:
-
-1. **Emergency** (`Emerge`): System is unusable
-2. **Alert** (`Alert`): Action must be taken immediately
-3. **Critical** (`Critical`): Critical conditions
-4. **Error** (`Error`): Error conditions
-5. **Warning** (`Warning`): Warning conditions
-6. **Notice** (`Notice`): Normal but significant condition
-7. **Info** (`Info`): Informational messages
-8. **Debug** (`Debug`): Debug-level messages
+- Package docs: `go doc github.com/yskomur/jourlog`
+- Rendered docs: `pkg.go.dev/github.com/yskomur/jourlog`
 
 ## License
 
-See the [LICENSE](LICENSE) file for details.
+See [LICENSE](LICENSE).

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,38 @@
+// Package jourlog provides structured logging and journal reading utilities for systemd-based
+// systems.
+//
+// # Logging
+//
+// Create a logger with NewJourlog, choose the minimum accepted level with SetLogLevel,
+// and write records with priority-specific methods such as Info, Error, or Debug.
+//
+//	logger := jourlog.NewJourlog()
+//	logger.SetLogLevel(journal.PriInfo)
+//	logger.Info("service started: pid=%d", os.Getpid())
+//
+// Each record is sent to systemd-journald with CODE_FILE, CODE_LINE, and CODE_FUNC
+// metadata fields derived from the caller.
+//
+// # Journal reading
+//
+// Open a reader with NewJournalReader, apply optional filters, then retrieve entries
+// sequentially with Retrieve.
+//
+//	reader, err := jourlog.NewJournalReader()
+//	if err != nil {
+//		// handle error
+//	}
+//	defer reader.Close()
+//
+//	_ = reader.LastHour()
+//	for {
+//		message, err := reader.Retrieve()
+//		if err != nil {
+//			break
+//		}
+//		fmt.Println(message)
+//	}
+//
+// The reader supports common filters such as SetUnit, SetPriority, SetHostname,
+// and convenience time windows like LastHour, LastDay, and Today.
+package jourlog

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,38 @@
+package jourlog_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/coreos/go-systemd/v22/journal"
+	"github.com/yskomur/jourlog"
+)
+
+func ExampleNewJourlog() {
+	logger := jourlog.NewJourlog()
+	logger.SetEcho(true)
+	logger.SetLogLevel(journal.PriInfo)
+	logger.Info("service started")
+}
+
+func ExampleNewJournalReader() {
+	reader, err := jourlog.NewJournalReader()
+	if err != nil {
+		log.Printf("journal unavailable: %v", err)
+		return
+	}
+	defer reader.Close()
+
+	if err := reader.LastHour(); err != nil {
+		log.Printf("unable to apply time filter: %v", err)
+		return
+	}
+
+	message, err := reader.Retrieve()
+	if err != nil {
+		log.Printf("unable to retrieve entry: %v", err)
+		return
+	}
+
+	fmt.Println(message)
+}

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
+github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=

--- a/jourlog.go
+++ b/jourlog.go
@@ -1,6 +1,3 @@
-// Package jourlog provides a Go interface for logging to systemd's journal.
-// It supports all standard log levels and can be configured to echo logs to the console.
-// The package also captures file, line, and function information for each log entry.
 package jourlog
 
 import (

--- a/jourread.go
+++ b/jourread.go
@@ -1,6 +1,3 @@
-// Package jourlog provides a Go interface for logging to systemd's journal.
-// It supports all standard log levels and can be configured to echo logs to the console.
-// The package also captures file, line, and function information for each log entry.
 package jourlog
 
 import (


### PR DESCRIPTION
### Motivation

- The package lacked a centralized GoDoc-style package comment and discoverable examples, and README examples referenced a non-existent global logger, causing confusion for consumers. 
- Adding examples and canonical package documentation improves `go doc`/`pkg.go.dev` rendering and makes the public API usage explicit. 

### Description

- Added a dedicated package comment file `doc.go` to provide GoDoc-oriented documentation for logging and journal reading. 
- Added `example_test.go` with `ExampleNewJourlog` and `ExampleNewJournalReader` so usage examples are discoverable by `go doc` and `pkg.go.dev`. 
- Updated `README.md` to align quick-start examples with the actual public API (use `NewJourlog` and `NewJournalReader`) and consolidated the API overview. 
- Removed duplicate package comment blocks from implementation files `jourlog.go` and `jourread.go`, ran `gofmt`, and ran `go mod tidy` which added dependency checksums to `go.sum`. 

### Testing

- Formatted files with `gofmt -w doc.go example_test.go jourlog.go jourread.go` which completed successfully. 
- Ran `go test ./...` which initially failed due to missing `go.sum` entries and then after `go mod tidy` failed to build because the environment lacks systemd development headers (`fatal error: systemd/sd-journal.h`), preventing full test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d00e918ac8325bc4d135dc83d88fe)